### PR TITLE
corrrect type parsing

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -16,6 +16,7 @@ import Parsing.FrontExpr
 import Parsing.Lex
 import Parsing.ParseEarley
 import System.IO (hFlush, stdout)
+import Control.Arrow
 
 main :: IO ()
 main = do
@@ -50,8 +51,8 @@ runLine = do
     lift $ print parsed'
     lift $ putStrLn "desugared:"
     case parsed' of
-        TypeDef _ _ constructors -> do 
-            put (venv, foldr (\(name, ctype) t -> insert name ctype t) tenv constructors)
+        TypeDef _ vars constructors -> do 
+            put (venv, foldr (\(name, ctype) t -> insert name ctype t) tenv (map (second $ Forall vars) constructors))
             runLine
         _ -> return ()
 

--- a/src/Inference/Infer.hs
+++ b/src/Inference/Infer.hs
@@ -10,7 +10,7 @@ import qualified Data.Set as Set
 import Data.Functor.Identity (Identity (runIdentity))
 import Data.List (nub)
 import Data.Bifunctor (Bifunctor(second))
-import Debug.Trace (traceM)
+import Debug.Trace (traceM, traceShow)
 
 type TypeEnv = Map.Map String CoreScheme
 
@@ -141,9 +141,9 @@ infer expr = case expr of
 
 
 deDataCons :: CoreType -> (CoreType, [CoreType])
-deDataCons t = case t of
+deDataCons t = traceShow t $ case t of
     TArr a b -> second (a :) $ deDataCons b
-    TCons n v -> (TCons n v, [])
+    a -> (a, [])
 
 patternType :: CorePattern -> InferM (CoreType, [(String, CoreScheme)])
 patternType pat = case pat of

--- a/src/Parsing/FrontExpr.hs
+++ b/src/Parsing/FrontExpr.hs
@@ -17,7 +17,7 @@ data FeExpr where
     deriving (Show)
 
 data Statement = Def String FeExpr | Expr FeExpr | TypeDef String [String] [DataCons] deriving (Show)
-type DataCons = (String, CoreScheme)
+type DataCons = (String, CoreType)
 data FePattern where
     FPaCons :: String -> [FePattern] -> FePattern
     FPaVar :: String -> FePattern


### PR DESCRIPTION
Parsing in type definitions works correctly now: arrows are right-associative and type functions have higher precedence than arrows